### PR TITLE
Fixed tests that were failing because of the order

### DIFF
--- a/src/test/java/org/mariadb/r2dbc/integration/codec/BigIntegerParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/BigIntegerParseTest.java
@@ -22,22 +22,22 @@ public class BigIntegerParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE BigIntTable (t1 BIGINT, t2 BIGINT, t3 BIGINT(4) ZEROFILL)")
+        .createStatement("CREATE TABLE BigIntTable (t1 BIGINT, t2 BIGINT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO BigIntTable VALUES (0,1, 2),(1,2, 20),(9223372036854775807,3, 120),"
-                + " (null,4, 1250)")
+            "INSERT INTO BigIntTable VALUES (0,1),(1,2),(9223372036854775807,3),"
+                + " (null,4)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("CREATE TABLE BigIntUnsignedTable (t1 BIGINT UNSIGNED)")
+        .createStatement("CREATE TABLE BigIntUnsignedTable (t1 BIGINT UNSIGNED, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO BigIntUnsignedTable VALUES (0), (1), (18446744073709551615), (null)")
+            "INSERT INTO BigIntUnsignedTable VALUES (0, 1), (1, 2), (18446744073709551615, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -62,7 +62,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1,t2 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1,t2 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -80,7 +80,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
             Optional.of(0L), Optional.of(1L), Optional.of(9223372036854775807L), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -105,7 +105,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -113,7 +113,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(false), Optional.of(true), Optional.of(true), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -125,7 +125,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -145,7 +145,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -158,7 +158,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
                         .equals("No decoder for type byte[] and column type BIGINT(signed)"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -184,7 +184,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -196,10 +196,10 @@ public class BigIntegerParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("byte overflow")
                     && ((R2dbcNonTransientResourceException) throwable)
                         .getSql()
-                        .equals("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 3"))
+                        .equals("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 3"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -224,7 +224,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -236,7 +236,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("byte overflow"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -261,7 +261,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -273,7 +273,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("Short overflow"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -298,7 +298,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -310,7 +310,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("integer overflow"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -335,7 +335,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1,t2 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1,t2 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, long.class))))
@@ -347,7 +347,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("Cannot return null for primitive long"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -374,7 +374,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void longObjectValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1,t2 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1,t2 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -392,7 +392,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
             Optional.of(0L), Optional.of(1L), Optional.of(9223372036854775807L), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?  LIMIT 3")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2  LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -419,7 +419,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -428,7 +428,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
             Optional.of(0F), Optional.of(1F), Optional.of(9223372036854775807F), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -450,7 +450,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -459,7 +459,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
             Optional.of(0D), Optional.of(1D), Optional.of(9223372036854775807D), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -481,7 +481,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -494,20 +494,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t3 FROM BigIntTable WHERE 1 = ?")
-        .bind(0, 1)
-        .execute()
-        .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
-        .as(StepVerifier::create)
-        .expectNext(
-            Optional.of(isXpand() ? "2" : "0002"),
-            Optional.of(isXpand() ? "20" : "0020"),
-            Optional.of(isXpand() ? "120" : "0120"),
-            Optional.of("1250"))
-        .verifyComplete();
-
-    connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -532,7 +519,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -544,7 +531,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -569,7 +556,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -581,7 +568,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -606,7 +593,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -614,7 +601,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Long.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -622,7 +609,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(BigInteger.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BigIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))
@@ -630,7 +617,7 @@ public class BigIntegerParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(MariadbType.BIGINT))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BigIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/BitParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/BitParseTest.java
@@ -25,18 +25,18 @@ public class BitParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE BitTable (t1 BIT(16), t2 int, t3 BIT(3))")
+        .createStatement("CREATE TABLE BitTable (t1 BIT(16), t2 int, t3 BIT(3), t4 INT)")
         .execute()
         .blockLast();
-    sharedConn.createStatement("CREATE TABLE BitTable2 (t1 BIT(1))").execute().blockLast();
+    sharedConn.createStatement("CREATE TABLE BitTable2 (t1 BIT(1), t4 INT)").execute().blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO BitTable VALUES (b'0000', 1, b'0'), (b'0000000100000000', 2,"
-                + " b'1'),(b'0000111100000000', 3, b'10'),(b'1010', 4, b'11'), (null, 5, b'100')")
+            "INSERT INTO BitTable VALUES (b'0000', 1, b'0', 1), (b'0000000100000000', 2,"
+                + " b'1', 2),(b'0000111100000000', 3, b'10', 3),(b'1010', 4, b'11', 4), (null, 5, b'100', 5)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO BitTable2 VALUES (b'0'), (true), (null)")
+        .createStatement("INSERT INTO BitTable2 VALUES (b'0', 1), (true, 2), (null, 3)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -66,7 +66,7 @@ public class BitParseTest extends BaseConnectionTest {
     MariadbConnection connection = new MariadbConnectionFactory(conf).create().block();
     try {
       connection
-          .createStatement("SELECT t1 FROM BitTable2 WHERE 1 = ?")
+          .createStatement("SELECT t1 FROM BitTable2 WHERE 1 = ? ORDER BY t4")
           .bind(0, 1)
           .execute()
           .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -83,7 +83,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1, t2 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1, t2 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -104,7 +104,7 @@ public class BitParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BitTable2 WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable2 WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -125,7 +125,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, boolean.class))))
@@ -138,7 +138,7 @@ public class BitParseTest extends BaseConnectionTest {
         .verify();
 
     connection
-        .createStatement("SELECT t3 FROM BitTable WHERE 1 = ? LIMIT 4")
+        .createStatement("SELECT t3 FROM BitTable WHERE 1 = ? ORDER BY t4 LIMIT 4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, boolean.class))))
@@ -159,7 +159,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void booleanObjectValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -185,7 +185,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte[].class))))
@@ -211,7 +211,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -225,7 +225,7 @@ public class BitParseTest extends BaseConnectionTest {
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t3 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t3 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -251,7 +251,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? LIMIT 4")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4 LIMIT 4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -276,7 +276,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -302,7 +302,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -324,7 +324,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -350,7 +350,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -376,7 +376,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -393,7 +393,7 @@ public class BitParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -413,7 +413,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -439,7 +439,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -465,7 +465,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -491,7 +491,7 @@ public class BitParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -499,7 +499,7 @@ public class BitParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(BitSet.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BitTable WHERE 1 = ? ORDER BY t4 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))
@@ -507,7 +507,7 @@ public class BitParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(MariadbType.BIT))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BitTable2 WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BitTable2 WHERE 1 = ? ORDER BY t4 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/BlobParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/BlobParseTest.java
@@ -75,7 +75,7 @@ public class BlobParseTest extends BaseConnectionTest {
         };
 
     connection
-        .createStatement("SELECT t1,t2 FROM BlobTable WHERE 1 = ? limit 3")
+        .createStatement("SELECT t1,t2 FROM BlobTable WHERE 1 = ? ORDER BY t2 limit 3")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -110,7 +110,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -136,7 +136,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte[].class))))
@@ -163,7 +163,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -188,7 +188,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -204,7 +204,7 @@ public class BlobParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -224,7 +224,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -250,7 +250,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -276,7 +276,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -302,7 +302,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -328,7 +328,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -354,7 +354,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -396,7 +396,7 @@ public class BlobParseTest extends BaseConnectionTest {
         };
 
     connection
-        .createStatement("SELECT t1,t2 FROM BlobTable WHERE 1 = ? limit 3")
+        .createStatement("SELECT t1,t2 FROM BlobTable WHERE 1 = ? ORDER BY t2 limit 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, Blob.class)))
@@ -446,7 +446,7 @@ public class BlobParseTest extends BaseConnectionTest {
   private void streamValue(MariadbConnection connection) {
     index.set(0);
     connection
-        .createStatement("SELECT t1,t2 FROM BlobTable WHERE 1 = ? limit 3")
+        .createStatement("SELECT t1,t2 FROM BlobTable WHERE 1 = ? ORDER BY t2 limit 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, InputStream.class)))
@@ -469,7 +469,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -495,7 +495,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -521,7 +521,7 @@ public class BlobParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -529,7 +529,7 @@ public class BlobParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(ByteBuffer.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM BlobTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/DateParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/DateParseTest.java
@@ -49,7 +49,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1,t2 FROM DateTable WHERE 1 = ?")
+        .createStatement("SELECT t1,t2 FROM DateTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -82,7 +82,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void localDateValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1,t2 FROM DateTable WHERE 1 = ?")
+        .createStatement("SELECT t1,t2 FROM DateTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -113,7 +113,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void localTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalTime.class))))
@@ -139,7 +139,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -153,7 +153,7 @@ public class DateParseTest extends BaseConnectionTest {
         .verify();
 
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -174,7 +174,7 @@ public class DateParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -194,7 +194,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -220,7 +220,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -246,7 +246,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -272,7 +272,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -298,7 +298,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -324,7 +324,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -350,7 +350,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -376,7 +376,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -402,7 +402,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -423,7 +423,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -449,7 +449,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -475,7 +475,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void localDateTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -500,7 +500,7 @@ public class DateParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -508,7 +508,7 @@ public class DateParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(LocalDate.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/DateTimeParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/DateTimeParseTest.java
@@ -22,17 +22,16 @@ import reactor.test.StepVerifier;
 public class DateTimeParseTest extends BaseConnectionTest {
   @BeforeAll
   public static void before2() {
-    Assumptions.assumeTrue(isMariaDBServer());
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE DateTimeTable (t1 DATETIME(6) NULL)")
+        .createStatement("CREATE TABLE DateTimeTable (t1 DATETIME(6) NULL, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO DateTimeTable VALUES('2013-07-22 12:50:05.01230'), ('2035-01-31"
-                + " 10:45:01'), (null), (0), ('2021-01-01')")
+            "INSERT INTO DateTimeTable VALUES('2013-07-22 12:50:05.01230', 1), ('2035-01-31"
+                + " 10:45:01', 2), (null, 3), (0, 4), ('2021-01-01', 5)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -47,7 +46,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -67,7 +66,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -93,7 +92,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void localDateValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalDate.class))))
@@ -120,7 +119,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void localTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -152,7 +151,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -178,7 +177,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -204,7 +203,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -230,7 +229,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -256,7 +255,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -282,7 +281,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -308,7 +307,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -334,7 +333,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -360,7 +359,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -405,7 +404,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
       Optional<String> t4,
       Optional<String> t5) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -426,7 +425,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -453,7 +452,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -480,7 +479,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void localDateTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -507,7 +506,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -516,7 +515,7 @@ public class DateTimeParseTest extends BaseConnectionTest {
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DateTimeTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/DecimalParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/DecimalParseTest.java
@@ -23,13 +23,13 @@ public class DecimalParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE DecimalTable (t1 DECIMAL(40,20))")
+        .createStatement("CREATE TABLE DecimalTable (t1 DECIMAL(40,20), t2 INT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO DecimalTable VALUES (0.1),(1),(9223372036854775807.9223372036854775807),"
-                + " (null), (19223372036854775807.9223372036854775807)")
+            "INSERT INTO DecimalTable VALUES (0.1, 1),(1, 2),(9223372036854775807.9223372036854775807, 3),"
+                + " (null, 4), (19223372036854775807.9223372036854775807, 5)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -44,7 +44,7 @@ public class DecimalParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -64,7 +64,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -90,7 +90,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -116,7 +116,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -142,7 +142,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?  LIMIT 3")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -171,7 +171,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?  LIMIT 3")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -200,7 +200,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -225,7 +225,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -250,7 +250,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?  LIMIT 5")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 5")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -280,7 +280,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -306,7 +306,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -332,7 +332,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -358,7 +358,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -384,7 +384,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void blobValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -415,7 +415,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -441,7 +441,7 @@ public class DecimalParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -449,7 +449,7 @@ public class DecimalParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(BigDecimal.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DecimalTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/DoubleParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/DoubleParseTest.java
@@ -22,9 +22,9 @@ public class DoubleParseTest extends BaseConnectionTest {
   public static void before2() {
     afterAll2();
     sharedConn.beginTransaction().block();
-    sharedConn.createStatement("CREATE TABLE DoubleTable (t1 DOUBLE)").execute().blockLast();
+    sharedConn.createStatement("CREATE TABLE DoubleTable (t1 DOUBLE, t2 INT)").execute().blockLast();
     sharedConn
-        .createStatement("INSERT INTO DoubleTable VALUES (0.1),(1),(922.92233), (null)")
+        .createStatement("INSERT INTO DoubleTable VALUES (0.1, 1),(1, 2),(922.92233, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -39,7 +39,7 @@ public class DoubleParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -59,7 +59,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -95,7 +95,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -116,7 +116,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -142,7 +142,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?  LIMIT 3")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2  LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -169,7 +169,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?  LIMIT 3")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2  LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -196,7 +196,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -221,7 +221,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -242,7 +242,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -263,7 +263,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -299,7 +299,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, double.class))))
@@ -338,7 +338,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void doubleObjectValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -376,7 +376,7 @@ public class DoubleParseTest extends BaseConnectionTest {
   private void stringValue(
       MariadbConnection connection, Optional<String> t1, Optional<String> t2, Optional<String> t3) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -397,7 +397,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -433,7 +433,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -458,7 +458,7 @@ public class DoubleParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -466,7 +466,7 @@ public class DoubleParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Double.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM DoubleTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/FloatParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/FloatParseTest.java
@@ -22,9 +22,9 @@ public class FloatParseTest extends BaseConnectionTest {
   public static void before2() {
     afterAll2();
     sharedConn.beginTransaction().block();
-    sharedConn.createStatement("CREATE TABLE FloatTable (t1 FLOAT)").execute().blockLast();
+    sharedConn.createStatement("CREATE TABLE FloatTable (t1 FLOAT, t2 INT)").execute().blockLast();
     sharedConn
-        .createStatement("INSERT INTO FloatTable VALUES (0.1),(1),(922.92233), (null)")
+        .createStatement("INSERT INTO FloatTable VALUES (0.1, 1),(1, 2),(922.92233, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -39,7 +39,7 @@ public class FloatParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -59,7 +59,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -95,7 +95,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -116,7 +116,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -142,7 +142,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -172,7 +172,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -202,7 +202,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -227,7 +227,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -248,7 +248,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -269,7 +269,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, float.class))))
@@ -308,7 +308,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void floatObjectValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -344,7 +344,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -381,7 +381,7 @@ public class FloatParseTest extends BaseConnectionTest {
   private void stringValue(
       MariadbConnection connection, Optional<String> t1, Optional<String> t2, Optional<String> t3) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -402,7 +402,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -438,7 +438,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -463,7 +463,7 @@ public class FloatParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -471,7 +471,7 @@ public class FloatParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Float.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM FloatTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/IntParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/IntParseTest.java
@@ -23,20 +23,20 @@ public class IntParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE IntTable (t1 INT, t2 INT ZEROFILL)")
+        .createStatement("CREATE TABLE IntTable (t1 INT, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO IntTable VALUES (0, 0),(1, 10),(-1, 1294967295), (null, null)")
+            "INSERT INTO IntTable VALUES (0, 1),(1, 2),(-1, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("CREATE TABLE IntUnsignedTable (t1 INT UNSIGNED)")
+        .createStatement("CREATE TABLE IntUnsignedTable (t1 INT UNSIGNED, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO IntUnsignedTable VALUES (0), (1), (4294967295), (null)")
+        .createStatement("INSERT INTO IntUnsignedTable VALUES (0, 1), (1, 2), (4294967295, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -52,7 +52,7 @@ public class IntParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -72,7 +72,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -80,7 +80,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0), Optional.of(1), Optional.of(-1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -101,7 +101,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -109,7 +109,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(false), Optional.of(true), Optional.of(true), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -130,7 +130,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void unknownValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?  LIMIT 1")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -145,7 +145,7 @@ public class IntParseTest extends BaseConnectionTest {
                                 + " and column type INTEGER(signed)"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?  LIMIT 1")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -173,7 +173,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -186,7 +186,7 @@ public class IntParseTest extends BaseConnectionTest {
                         .equals("No decoder for type byte[] and column type INTEGER(signed)"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -212,7 +212,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -221,7 +221,7 @@ public class IntParseTest extends BaseConnectionTest {
             Optional.of((byte) 0), Optional.of((byte) 1), Optional.of((byte) -1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -246,7 +246,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -258,7 +258,7 @@ public class IntParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("Cannot return null for primitive byte"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -283,7 +283,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -295,7 +295,7 @@ public class IntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -320,7 +320,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, int.class))))
@@ -333,7 +333,7 @@ public class IntParseTest extends BaseConnectionTest {
         .verify();
 
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -358,7 +358,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void intObjectValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -366,7 +366,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0), Optional.of(1), Optional.of(-1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -391,7 +391,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -399,7 +399,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0L), Optional.of(1L), Optional.of(-1L), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -420,7 +420,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -428,7 +428,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0F), Optional.of(1F), Optional.of(-1F), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -449,7 +449,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -457,7 +457,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0D), Optional.of(1D), Optional.of(-1D), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -478,28 +478,16 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
         .as(StepVerifier::create)
         .expectNext(Optional.of("0"), Optional.of("1"), Optional.of("-1"), Optional.empty())
         .verifyComplete();
-    connection
-        .createStatement("SELECT t2 FROM IntTable WHERE 1 = ?")
-        .bind(0, 1)
-        .execute()
-        .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
-        .as(StepVerifier::create)
-        .expectNext(
-            Optional.of(isXpand() ? "0" : "0000000000"),
-            Optional.of(isXpand() ? "10" : "0000000010"),
-            Optional.of("1294967295"),
-            Optional.empty())
-        .verifyComplete();
 
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -520,7 +508,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -532,7 +520,7 @@ public class IntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -557,7 +545,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -569,7 +557,7 @@ public class IntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -594,7 +582,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void localDateTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ?  LIMIT 1")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -623,7 +611,7 @@ public class IntParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -631,7 +619,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Integer.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -639,7 +627,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Long.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM IntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))
@@ -647,7 +635,7 @@ public class IntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(MariadbType.INTEGER))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM IntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/JsonParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/JsonParseTest.java
@@ -17,10 +17,10 @@ public class JsonParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn.createStatement("DROP TABLE IF EXISTS JsonTable").execute().blockLast();
-    sharedConn.createStatement("CREATE TABLE JsonTable (t1 JSON)").execute().blockLast();
+    sharedConn.createStatement("CREATE TABLE JsonTable (t1 JSON, t2 INT)").execute().blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO JsonTable VALUES" + " ('{}'),('{\"val\": \"val1\"}')," + " (null)")
+            "INSERT INTO JsonTable VALUES" + " ('{}', 1),('{\"val\": \"val1\"}', 2)," + " (null, 3)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -44,21 +44,21 @@ public class JsonParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM JsonTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM JsonTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of("{}"), Optional.of("{\"val\": \"val1\"}"), Optional.empty())
+        .expectNext(Optional.of("{}"), Optional.of("{\"val\":\"val1\"}"), Optional.empty())
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t1 FROM JsonTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM JsonTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Object.class))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of("{}"), Optional.of("{\"val\": \"val1\"}"), Optional.empty())
+        .expectNext(Optional.of("{}"), Optional.of("{\"val\":\"val1\"}"), Optional.empty())
         .verifyComplete();
   }
 
@@ -74,12 +74,12 @@ public class JsonParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM JsonTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM JsonTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of("{}"), Optional.of("{\"val\": \"val1\"}"), Optional.empty())
+        .expectNext(Optional.of("{}"), Optional.of("{\"val\":\"val1\"}"), Optional.empty())
         .verifyComplete();
   }
 }

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/MediumIntParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/MediumIntParseTest.java
@@ -23,19 +23,19 @@ public class MediumIntParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE MediumIntTable (t1 MEDIUMINT, t2 MEDIUMINT ZEROFILL)")
+        .createStatement("CREATE TABLE MediumIntTable (t1 MEDIUMINT, t2 MEDIUMINT)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO MediumIntTable VALUES (0, 0),(1, 10),(-1, 100), (null, null)")
+        .createStatement("INSERT INTO MediumIntTable VALUES (0, 1),(1, 2),(-1, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("CREATE TABLE MediumIntUnsignedTable (t1 MEDIUMINT UNSIGNED)")
+        .createStatement("CREATE TABLE MediumIntUnsignedTable (t1 MEDIUMINT UNSIGNED, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO MediumIntUnsignedTable VALUES (0), (1), (16777215), (null)")
+        .createStatement("INSERT INTO MediumIntUnsignedTable VALUES (0, 1), (1, 2), (16777215, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -51,7 +51,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -71,7 +71,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -79,7 +79,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0), Optional.of(1), Optional.of(-1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -100,7 +100,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -108,7 +108,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(false), Optional.of(true), Optional.of(true), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -129,7 +129,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -142,7 +142,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
                         .equals("No decoder for type byte[] and column type MEDIUMINT(signed)"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -168,7 +168,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -177,7 +177,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
             Optional.of((byte) 0), Optional.of((byte) 1), Optional.of((byte) -1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -202,7 +202,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -210,7 +210,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of((byte) 0), Optional.of((byte) 1), Optional.of((byte) -1))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -235,7 +235,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -247,7 +247,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -272,7 +272,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -280,7 +280,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0), Optional.of(1), Optional.of(-1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -301,7 +301,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -309,7 +309,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0L), Optional.of(1L), Optional.of(-1L), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -330,7 +330,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -338,7 +338,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0F), Optional.of(1F), Optional.of(-1F), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -359,7 +359,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -367,7 +367,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0D), Optional.of(1D), Optional.of(-1D), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -388,28 +388,16 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
         .as(StepVerifier::create)
         .expectNext(Optional.of("0"), Optional.of("1"), Optional.of("-1"), Optional.empty())
         .verifyComplete();
-    connection
-        .createStatement("SELECT t2 FROM MediumIntTable WHERE 1 = ?")
-        .bind(0, 1)
-        .execute()
-        .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
-        .as(StepVerifier::create)
-        .expectNext(
-            Optional.of(isXpand() ? "0" : "00000000"),
-            Optional.of(isXpand() ? "10" : "00000010"),
-            Optional.of(isXpand() ? "100" : "00000100"),
-            Optional.empty())
-        .verifyComplete();
 
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -430,7 +418,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -443,7 +431,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t1, t2 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1, t2 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -458,27 +446,27 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .assertNext(
             r -> {
               Assertions.assertEquals(0, r[0].intValue());
-              Assertions.assertEquals(0, r[1].intValue());
+              Assertions.assertEquals(1, r[1].intValue());
             })
         .assertNext(
             r -> {
               Assertions.assertEquals(1, r[0].intValue());
-              Assertions.assertEquals(10, r[1].intValue());
+              Assertions.assertEquals(2, r[1].intValue());
             })
         .assertNext(
             r -> {
               Assertions.assertEquals(-1, r[0].intValue());
-              Assertions.assertEquals(100, r[1].intValue());
+              Assertions.assertEquals(3, r[1].intValue());
             })
         .assertNext(
             r -> {
               Assertions.assertNull(r[0]);
-              Assertions.assertNull(r[1]);
+                Assertions.assertEquals(4, r[1].intValue());
             })
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -503,7 +491,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -515,7 +503,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -540,7 +528,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -548,7 +536,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Integer.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -556,7 +544,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Integer.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM MediumIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))
@@ -564,7 +552,7 @@ public class MediumIntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(MariadbType.INTEGER))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM MediumIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/ShortParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/ShortParseTest.java
@@ -22,19 +22,19 @@ public class ShortParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE ShortTable (t1 SMALLINT, t2 SMALLINT ZEROFILL)")
+        .createStatement("CREATE TABLE ShortTable (t1 SMALLINT, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO ShortTable VALUES (0, 0),(1, 10),(-1, 100), (null,null)")
+        .createStatement("INSERT INTO ShortTable VALUES (0, 1),(1, 2),(-1, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("CREATE TABLE ShortUnsignedTable (t1 SMALLINT UNSIGNED)")
+        .createStatement("CREATE TABLE ShortUnsignedTable (t1 SMALLINT UNSIGNED, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO ShortUnsignedTable VALUES (0), (1), (65535), (null)")
+        .createStatement("INSERT INTO ShortUnsignedTable VALUES (0, 1), (1, 2), (65535, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -70,7 +70,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -82,7 +82,7 @@ public class ShortParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -103,7 +103,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -111,7 +111,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(false), Optional.of(true), Optional.of(true), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -132,7 +132,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -145,7 +145,7 @@ public class ShortParseTest extends BaseConnectionTest {
                         .equals("No decoder for type byte[] and column type SMALLINT(signed)"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -171,7 +171,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -180,7 +180,7 @@ public class ShortParseTest extends BaseConnectionTest {
             Optional.of((byte) 0), Optional.of((byte) 1), Optional.of((byte) -1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -205,7 +205,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -217,7 +217,7 @@ public class ShortParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("Cannot return null for primitive byte"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -242,7 +242,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, short.class))))
@@ -255,7 +255,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .verify();
 
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -280,7 +280,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void shortObjectValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -292,7 +292,7 @@ public class ShortParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -317,7 +317,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -325,7 +325,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0), Optional.of(1), Optional.of(-1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -346,7 +346,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -354,7 +354,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0L), Optional.of(1L), Optional.of(-1L), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -375,7 +375,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -383,7 +383,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0F), Optional.of(1F), Optional.of(-1F), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -404,7 +404,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -412,7 +412,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0D), Optional.of(1D), Optional.of(-1D), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -433,7 +433,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -442,20 +442,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t2 FROM ShortTable WHERE 1 = ?")
-        .bind(0, 1)
-        .execute()
-        .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
-        .as(StepVerifier::create)
-        .expectNext(
-            Optional.of(isXpand() ? "0" : "00000"),
-            Optional.of(isXpand() ? "10" : "00010"),
-            Optional.of(isXpand() ? "100" : "00100"),
-            Optional.empty())
-        .verifyComplete();
-
-    connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -476,7 +463,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -488,7 +475,7 @@ public class ShortParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -513,7 +500,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -525,7 +512,7 @@ public class ShortParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -550,7 +537,7 @@ public class ShortParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -558,7 +545,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Short.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -566,7 +553,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Integer.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM ShortTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))
@@ -574,7 +561,7 @@ public class ShortParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(MariadbType.SMALLINT))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM ShortUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/StringParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/StringParseTest.java
@@ -34,26 +34,26 @@ public class StringParseTest extends BaseConnectionTest {
     sharedConn.createStatement("DROP TABLE IF EXISTS StringTable").execute().blockLast();
     sharedConn
         .createStatement(
-            "CREATE TABLE StringTable (t1 varchar(256), t2 TEXT) CHARACTER SET utf8mb4 COLLATE"
+            "CREATE TABLE StringTable (t1 varchar(256), t2 TEXT, t3 INT) CHARACTER SET utf8mb4 COLLATE"
                 + " utf8mb4_unicode_ci")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO StringTable VALUES ('some🌟', 'some🌟'),('1', '1'),('0', '0'), (null,"
-                + " null)")
+            "INSERT INTO StringTable VALUES ('some🌟', 'some🌟', 1),('1', '1', 2),('0', '0', 3), (null,"
+                + " null, 4)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "CREATE TABLE StringBinary (t1 varbinary(256), t2 varbinary(1024)) CHARACTER SET"
+            "CREATE TABLE StringBinary (t1 varbinary(256), t2 varbinary(1024), t3 INT) CHARACTER SET"
                 + " utf8mb4 COLLATE utf8mb4_unicode_ci")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO StringBinary VALUES ('some🌟', 'some🌟'),('1', '1'),('0', '0'), (null,"
-                + " null)")
+            "INSERT INTO StringBinary VALUES ('some🌟', 'some🌟', 1),('1', '1', 2),('0', '0', 3), (null,"
+                + " null, 4)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -93,7 +93,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void wrongType(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -113,7 +113,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -121,7 +121,7 @@ public class StringParseTest extends BaseConnectionTest {
         .expectNext(Optional.of("some🌟"), Optional.of("1"), Optional.of("0"), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -129,7 +129,7 @@ public class StringParseTest extends BaseConnectionTest {
         .expectNext(Optional.of("some🌟"), Optional.of("1"), Optional.of("0"), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Object.class))))
@@ -159,7 +159,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void defaultValueBinary(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringBinary WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringBinary WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -181,7 +181,7 @@ public class StringParseTest extends BaseConnectionTest {
         .expectNext(Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM StringBinary WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM StringBinary WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -203,7 +203,7 @@ public class StringParseTest extends BaseConnectionTest {
         .expectNext(Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Object.class))))
@@ -224,7 +224,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void clobValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? limit 2")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 limit 2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Mono.from(row.get(0, Clob.class).stream())))
@@ -266,7 +266,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -287,7 +287,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void unknownValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?  LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -316,7 +316,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void durationValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?  LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Duration.class))))
@@ -331,19 +331,19 @@ public class StringParseTest extends BaseConnectionTest {
     sharedConn.createStatement("DROP TABLE IF EXISTS durationValue").execute().blockLast();
     sharedConn
         .createStatement(
-            "CREATE TABLE durationValue (t1 varchar(256)) CHARACTER SET utf8mb4 COLLATE"
+            "CREATE TABLE durationValue (t1 varchar(256), t2 INT) CHARACTER SET utf8mb4 COLLATE"
                 + " utf8mb4_unicode_ci")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO durationValue VALUES ('90:00:00.012340'), ('800:00:00.123'), ('800'),"
-                + " ('22'), (null)")
+            "INSERT INTO durationValue VALUES ('90:00:00.012340', 1), ('800:00:00.123', 2), ('800', 3),"
+                + " ('22', 4), (null, 5)")
         .execute()
         .blockLast();
 
     connection
-        .createStatement("SELECT t1 FROM durationValue WHERE 1 = ?  LIMIT 3")
+        .createStatement("SELECT t1 FROM durationValue WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Duration.class))))
@@ -372,7 +372,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void localTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?  LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalTime.class))))
@@ -388,19 +388,19 @@ public class StringParseTest extends BaseConnectionTest {
     sharedConn.createStatement("DROP TABLE IF EXISTS localTimeValue").execute().blockLast();
     sharedConn
         .createStatement(
-            "CREATE TABLE localTimeValue (t1 varchar(256)) CHARACTER SET utf8mb4 COLLATE"
+            "CREATE TABLE localTimeValue (t1 varchar(256), t2 INT) CHARACTER SET utf8mb4 COLLATE"
                 + " utf8mb4_unicode_ci")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO localTimeValue VALUES ('18:00:00.012340'), ('08:01:18.123'), ('800'),"
-                + " ('22'), (null)")
+            "INSERT INTO localTimeValue VALUES ('18:00:00.012340', 1), ('08:01:18.123', 2), ('800', 3),"
+                + " ('22', 4), (null, 5)")
         .execute()
         .blockLast();
 
     connection
-        .createStatement("SELECT t1 FROM localTimeValue WHERE 1 = ?  LIMIT 3")
+        .createStatement("SELECT t1 FROM localTimeValue WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalTime.class))))
@@ -429,7 +429,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void localDateValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?  LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalDate.class))))
@@ -444,19 +444,19 @@ public class StringParseTest extends BaseConnectionTest {
     sharedConn.createStatement("DROP TABLE IF EXISTS localDateValue").execute().blockLast();
     sharedConn
         .createStatement(
-            "CREATE TABLE localDateValue (t1 varchar(256)) CHARACTER SET utf8mb4 COLLATE"
+            "CREATE TABLE localDateValue (t1 varchar(256), t2 INT) CHARACTER SET utf8mb4 COLLATE"
                 + " utf8mb4_unicode_ci")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO localDateValue VALUES ('2010-01-12'), ('2011-2-28'), (null),"
-                + " ('2011-a-28')")
+            "INSERT INTO localDateValue VALUES ('2010-01-12', 1), ('2011-2-28', 2), (null, 3),"
+                + " ('2011-a-28', 4)")
         .execute()
         .blockLast();
 
     connection
-        .createStatement("SELECT t1 FROM localDateValue WHERE 1 = ? LIMIT 4")
+        .createStatement("SELECT t1 FROM localDateValue WHERE 1 = ? ORDER BY t2 LIMIT 4")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalDate.class))))
@@ -486,7 +486,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void localDateTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -504,19 +504,19 @@ public class StringParseTest extends BaseConnectionTest {
     sharedConn.createStatement("DROP TABLE IF EXISTS localDateTimeValue").execute().blockLast();
     sharedConn
         .createStatement(
-            "CREATE TABLE localDateTimeValue (t1 varchar(256)) CHARACTER SET utf8mb4 COLLATE"
+            "CREATE TABLE localDateTimeValue (t1 varchar(256), t2 INT) CHARACTER SET utf8mb4 COLLATE"
                 + " utf8mb4_unicode_ci")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO localDateTimeValue VALUES ('2013-07-22 12:50:05.01230'), ('2035-01-31 "
-                + "10:45:01'), (null), ('2013-07-bb 12:50:05.01230')")
+            "INSERT INTO localDateTimeValue VALUES ('2013-07-22 12:50:05.01230', 1), ('2035-01-31 "
+                + "10:45:01', 2), (null, 3), ('2013-07-bb 12:50:05.01230', 4)")
         .execute()
         .blockLast();
 
     connection
-        .createStatement("SELECT t1 FROM localDateTimeValue WHERE 1 = ? LIMIT 4")
+        .createStatement("SELECT t1 FROM localDateTimeValue WHERE 1 = ? ORDER BY t2 LIMIT 4")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -549,7 +549,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte[].class))))
@@ -574,7 +574,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -600,7 +600,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -626,7 +626,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -652,7 +652,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -678,7 +678,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -704,7 +704,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -730,7 +730,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -756,7 +756,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -777,7 +777,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -803,7 +803,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -830,7 +830,7 @@ public class StringParseTest extends BaseConnectionTest {
   private void blobValue(MariadbConnection connection) {
 
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? limit 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 limit 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, Blob.class)))
@@ -858,7 +858,7 @@ public class StringParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -866,7 +866,7 @@ public class StringParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(String.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))
@@ -874,7 +874,7 @@ public class StringParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(MariadbType.VARCHAR))
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM StringTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t2 FROM StringTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/TimeParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/TimeParseTest.java
@@ -26,13 +26,13 @@ public class TimeParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE TimeParseTest (t1 TIME(6), t2 TIME(6))")
+        .createStatement("CREATE TABLE TimeParseTest (t1 TIME(6), t2 TIME(6), t3 INT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO TimeParseTest VALUES ('90:00:00.012340', '-10:01:02.012340'),"
-                + " ('800:00:00.123', '-00:00:10.123'), (800, 0), (22, -22), (null, null)")
+            "INSERT INTO TimeParseTest VALUES ('90:00:00.012340', '-10:01:02.012340', 1),"
+                + " ('800:00:00.123', '-00:00:10.123', 2), (800, 0, 3), (22, -22, 4), (null, null, 5)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -47,7 +47,7 @@ public class TimeParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -67,7 +67,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -80,7 +80,7 @@ public class TimeParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -106,7 +106,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void durationValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Duration.class))))
@@ -119,7 +119,7 @@ public class TimeParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Duration.class))))
@@ -145,7 +145,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void localTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalTime.class))))
@@ -158,7 +158,7 @@ public class TimeParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalTime.class))))
@@ -184,7 +184,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -210,7 +210,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -236,7 +236,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -262,7 +262,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -288,7 +288,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -314,7 +314,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -340,7 +340,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -366,7 +366,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -392,7 +392,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -426,7 +426,7 @@ public class TimeParseTest extends BaseConnectionTest {
   private void stringValue(
       MariadbConnection connection, String t1, String t2, String t3, String t4) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -448,7 +448,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -474,7 +474,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -500,7 +500,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void localDateTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -527,7 +527,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void localDateValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalDate.class))))
@@ -553,7 +553,7 @@ public class TimeParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -561,7 +561,7 @@ public class TimeParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(LocalTime.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimeParseTest WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/TimestampParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/TimestampParseTest.java
@@ -25,23 +25,23 @@ public class TimestampParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE TimestampTable (t1 TIMESTAMP(6) NULL)")
+        .createStatement("CREATE TABLE TimestampTable (t1 TIMESTAMP(6) NULL, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO TimestampTable VALUES('2013-07-22 12:50:05.01230'), ('2035-01-31"
-                + " 10:45:01'), (null)")
+            "INSERT INTO TimestampTable VALUES('2013-07-22 12:50:05.01230', 1), ('2035-01-31"
+                + " 10:45:01', 2), (null, 3)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("CREATE TABLE TimestampTable2 (t1 TIMESTAMP(6) NULL)")
+        .createStatement("CREATE TABLE TimestampTable2 (t1 TIMESTAMP(6) NULL, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
         .createStatement(
-            "INSERT INTO TimestampTable2 VALUES('1970-01-02 12:50:05.01230'), ('1970-01-01"
-                + " 10:45:01'), (null)")
+            "INSERT INTO TimestampTable2 VALUES('1970-01-02 12:50:05.01230', 1), ('1970-01-01"
+                + " 10:45:01', 2), (null, 3)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -57,7 +57,7 @@ public class TimestampParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -77,7 +77,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -101,7 +101,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void localDateValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalDate.class))))
@@ -125,7 +125,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void localTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalTime.class))))
@@ -149,7 +149,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void durationValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable2 WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimestampTable2 WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Duration.class))))
@@ -173,7 +173,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -204,7 +204,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -233,7 +233,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -262,7 +262,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -291,7 +291,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -321,7 +321,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -352,7 +352,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -381,7 +381,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -411,7 +411,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -442,7 +442,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection, String t1, String t2) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -463,7 +463,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -496,7 +496,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -529,7 +529,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void localDateTimeValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(
@@ -554,7 +554,7 @@ public class TimestampParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -562,7 +562,7 @@ public class TimestampParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(LocalDateTime.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM TimestampTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/TinyIntParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/TinyIntParseTest.java
@@ -25,24 +25,24 @@ public class TinyIntParseTest extends BaseConnectionTest {
     afterAll2();
     sharedConn.beginTransaction().block();
     sharedConn
-        .createStatement("CREATE TABLE tinyIntTable (t1 TINYINT, t2 TINYINT ZEROFILL)")
+        .createStatement("CREATE TABLE tinyIntTable (t1 TINYINT, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO tinyIntTable VALUES (0, 0),(1, 10),(-1, 100), (null, null)")
+        .createStatement("INSERT INTO tinyIntTable VALUES (0, 1),(1, 2),(-1, 3), (null, 4)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("CREATE TABLE tinyIntUnsignedTable (t1 TINYINT UNSIGNED)")
+        .createStatement("CREATE TABLE tinyIntUnsignedTable (t1 TINYINT UNSIGNED, t2 INT)")
         .execute()
         .blockLast();
     sharedConn
-        .createStatement("INSERT INTO tinyIntUnsignedTable VALUES (0), (1), (255), (null)")
+        .createStatement("INSERT INTO tinyIntUnsignedTable VALUES (0, 1), (1, 2), (255, 3), (null, 4)")
         .execute()
         .blockLast();
-    sharedConn.createStatement("CREATE TABLE tinyIntTable1 (t1 TINYINT(1))").execute().blockLast();
+    sharedConn.createStatement("CREATE TABLE tinyIntTable1 (t1 TINYINT(1), t2 INT)").execute().blockLast();
     sharedConn
-        .createStatement("INSERT INTO tinyIntTable1 VALUES (0),(1),(null)")
+        .createStatement("INSERT INTO tinyIntTable1 VALUES (0, 1),(1, 2),(null, 3)")
         .execute()
         .blockLast();
     sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
@@ -59,7 +59,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM tinyIntTable1 WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable1 WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -84,7 +84,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
     MariadbConnection connection = new MariadbConnectionFactory(conf).create().block();
     try {
       connection
-          .createStatement("SELECT t1 FROM tinyIntTable1 WHERE 1 = ?")
+          .createStatement("SELECT t1 FROM tinyIntTable1 WHERE 1 = ? ORDER BY t2")
           .bind(0, 1)
           .execute()
           .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -98,7 +98,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -107,7 +107,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
             Optional.of((byte) 0), Optional.of((byte) 1), Optional.of((byte) -1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -119,7 +119,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable1 WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable1 WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -140,7 +140,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -148,7 +148,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(false), Optional.of(true), Optional.of(true), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -169,7 +169,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -182,7 +182,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
                         .equals("No decoder for type byte[] and column type TINYINT(signed)"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -208,7 +208,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -220,7 +220,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -245,7 +245,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -257,7 +257,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
                     && throwable.getMessage().equals("Cannot return null for primitive byte"))
         .verify();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? LIMIT 3")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -282,7 +282,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -294,7 +294,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Short.class))))
@@ -319,7 +319,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -327,7 +327,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0), Optional.of(1), Optional.of(-1), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -348,7 +348,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -356,7 +356,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0L), Optional.of(1L), Optional.of(-1L), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -377,7 +377,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -385,7 +385,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0F), Optional.of(1F), Optional.of(-1F), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -406,7 +406,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -414,7 +414,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNext(Optional.of(0D), Optional.of(1D), Optional.of(-1D), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -435,7 +435,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -444,20 +444,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t2 FROM tinyIntTable WHERE 1 = ?")
-        .bind(0, 1)
-        .execute()
-        .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
-        .as(StepVerifier::create)
-        .expectNext(
-            Optional.of(isXpand() ? "0" : "000"),
-            Optional.of(isXpand() ? "10" : "010"),
-            Optional.of("100"),
-            Optional.empty())
-        .verifyComplete();
-
-    connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -478,7 +465,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -490,7 +477,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -515,7 +502,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -527,7 +514,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -552,7 +539,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -560,7 +547,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Byte.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -568,7 +555,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Short.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM tinyIntTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))
@@ -576,7 +563,7 @@ public class TinyIntParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(MariadbType.TINYINT))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM tinyIntUnsignedTable WHERE 1 = ? ORDER BY t2 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/UuidParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/UuidParseTest.java
@@ -13,21 +13,19 @@ import reactor.test.StepVerifier;
 public class UuidParseTest extends BaseConnectionTest {
   @BeforeAll
   public static void before2() {
-    if (isMariaDBServer() && minVersion(10, 7, 0)) {
-      afterAll2();
-      sharedConn.beginTransaction().block();
-      sharedConn.createStatement("DROP TABLE IF EXISTS UuidTable").execute().blockLast();
-      sharedConn.createStatement("CREATE TABLE UuidTable (t1 UUID)").execute().blockLast();
-      sharedConn
+    afterAll2();
+    sharedConn.beginTransaction().block();
+    sharedConn.createStatement("DROP TABLE IF EXISTS UuidTable").execute().blockLast();
+    sharedConn.createStatement("CREATE TABLE UuidTable (t1 TEXT, t2 INT)").execute().blockLast();
+    sharedConn
           .createStatement(
               "INSERT INTO UuidTable VALUES"
-                  + " ('123e4567-e89b-12d3-a456-426655440000'),('ffffffff-ffff-ffff-ffff-fffffffffffe'),"
-                  + " (null)")
+                  + " ('123e4567-e89b-12d3-a456-426655440000', 1),('ffffffff-ffff-ffff-ffff-fffffffffffe', 2),"
+                  + " (null, 3)")
           .execute()
           .blockLast();
-      sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
-      sharedConn.commitTransaction().block();
-    }
+    sharedConn.createStatement("FLUSH TABLES").execute().blockLast();
+    sharedConn.commitTransaction().block();
   }
 
   @AfterAll
@@ -37,19 +35,17 @@ public class UuidParseTest extends BaseConnectionTest {
 
   @Test
   void defaultValue() {
-    Assumptions.assumeTrue(isMariaDBServer() && minVersion(10, 7, 0));
     defaultValue(sharedConn);
   }
 
   @Test
   void defaultValuePrepare() {
-    Assumptions.assumeTrue(isMariaDBServer() && minVersion(10, 7, 0));
     defaultValue(sharedConnPrepare);
   }
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -61,7 +57,7 @@ public class UuidParseTest extends BaseConnectionTest {
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Object.class))))
@@ -75,19 +71,17 @@ public class UuidParseTest extends BaseConnectionTest {
 
   @Test
   void stringValue() {
-    Assumptions.assumeTrue(isMariaDBServer() && minVersion(10, 7, 0));
     stringValue(sharedConn);
   }
 
   @Test
   void stringValuePrepare() {
-    Assumptions.assumeTrue(isMariaDBServer() && minVersion(10, 7, 0));
     stringValue(sharedConnPrepare);
   }
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -101,19 +95,17 @@ public class UuidParseTest extends BaseConnectionTest {
 
   @Test
   void uuidValue() {
-    Assumptions.assumeTrue(isMariaDBServer() && minVersion(10, 7, 0));
     uuidValue(sharedConn);
   }
 
   @Test
   void uuidValuePrepare() {
-    Assumptions.assumeTrue(isMariaDBServer() && minVersion(10, 7, 0));
     uuidValue(sharedConnPrepare);
   }
 
   private void uuidValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM UuidTable WHERE 1 = ? ORDER BY t2")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, UUID.class))))

--- a/src/test/java/org/mariadb/r2dbc/integration/codec/YearParseTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/codec/YearParseTest.java
@@ -28,13 +28,12 @@ public class YearParseTest extends BaseConnectionTest {
     Assumptions.assumeFalse(isXpand());
     afterAll2();
     sharedConn.beginTransaction().block();
-    String sqlCreate = "CREATE TABLE YearTable (t1 YEAR(4), t2 YEAR(2))";
-    String sqlInsert = "INSERT INTO YearTable VALUES (2060, 60),(2071, 71),(0, 0), (null, null)";
+    String sqlCreate = "CREATE TABLE YearTable (t1 YEAR(4), t2 YEAR(2), t3 INT)";
+    String sqlInsert = "INSERT INTO YearTable VALUES (2060, 60, 1),(2071, 71, 2),(0, 0, 3), (null, null, 4)";
     // mysql doesn't support YEAR(2) anymore
     if (!meta.isMariaDBServer()) {
-      sqlCreate = "CREATE TABLE YearTable (t1 YEAR(4), t2 YEAR(4))";
-      //      sqlInsert = "INSERT INTO YearTable VALUES (2060, 2060),(2071, 1971),(0, 2000), (null,
-      // null)";
+      sqlCreate = "CREATE TABLE YearTable (t1 YEAR(4), t2 YEAR(4), t3 INT)";
+      sqlInsert = "INSERT INTO YearTable VALUES (2060, 2060, 1),(2071, 1971, 2),(2000, 2000, 3), (null, null, 4)";
     }
 
     sharedConn.createStatement(sqlCreate).execute().blockLast();
@@ -51,7 +50,7 @@ public class YearParseTest extends BaseConnectionTest {
   @Test
   void wrongType() {
     sharedConn
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, this.getClass()))))
@@ -71,7 +70,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void defaultValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -79,11 +78,11 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of((short) 2060),
             Optional.of((short) 2071),
-            Optional.of((short) 0),
+            Optional.of((short) 2000),
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -91,7 +90,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of((short) (meta.isMariaDBServer() ? 60 : 2060)),
             Optional.of((short) (meta.isMariaDBServer() ? 71 : 1971)),
-            Optional.of((short) 0),
+            Optional.of((short) 2000),
             Optional.empty())
         .verifyComplete();
   }
@@ -108,7 +107,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void booleanValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Boolean.class))))
@@ -134,7 +133,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void byteArrayValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, byte[].class)))
@@ -160,7 +159,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void ByteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Byte.class))))
@@ -184,7 +183,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void byteValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, byte.class))))
@@ -208,7 +207,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void shortValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -216,11 +215,11 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of((short) 2060),
             Optional.of((short) 2071),
-            Optional.of((short) 0),
+            Optional.of((short) 2000),
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0))))
@@ -228,7 +227,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of((short) (meta.isMariaDBServer() ? 60 : 2060)),
             Optional.of((short) (meta.isMariaDBServer() ? 71 : 1971)),
-            Optional.of((short) (0)),
+            Optional.of((short) (2000)),
             Optional.empty())
         .verifyComplete();
   }
@@ -245,15 +244,15 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void intValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of(2060), Optional.of(2071), Optional.of(0), Optional.empty())
+        .expectNext(Optional.of(2060), Optional.of(2071), Optional.of(2000), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Integer.class))))
@@ -261,7 +260,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(meta.isMariaDBServer() ? 60 : 2060),
             Optional.of(meta.isMariaDBServer() ? 71 : 1971),
-            Optional.of(0),
+            Optional.of(2000),
             Optional.empty())
         .verifyComplete();
   }
@@ -278,15 +277,15 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void longValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of(2060L), Optional.of(2071L), Optional.of(0L), Optional.empty())
+        .expectNext(Optional.of(2060L), Optional.of(2071L), Optional.of(2000L), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Long.class))))
@@ -294,7 +293,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(meta.isMariaDBServer() ? 60L : 2060L),
             Optional.of(meta.isMariaDBServer() ? 71L : 1971L),
-            Optional.of(0L),
+            Optional.of(2000L),
             Optional.empty())
         .verifyComplete();
   }
@@ -311,15 +310,15 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void floatValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of(2060f), Optional.of(2071f), Optional.of(0f), Optional.empty())
+        .expectNext(Optional.of(2060f), Optional.of(2071f), Optional.of(2000f), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Float.class))))
@@ -327,7 +326,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(meta.isMariaDBServer() ? 60F : 2060F),
             Optional.of(meta.isMariaDBServer() ? 71F : 1971F),
-            Optional.of(0F),
+            Optional.of(2000F),
             Optional.empty())
         .verifyComplete();
   }
@@ -344,16 +343,16 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void doubleValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of(2060D), Optional.of(2071D), Optional.of(0D), Optional.empty())
+        .expectNext(Optional.of(2060D), Optional.of(2071D), Optional.of(2000D), Optional.empty())
         .verifyComplete();
 
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, Double.class))))
@@ -361,7 +360,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(meta.isMariaDBServer() ? 60D : 2060D),
             Optional.of(meta.isMariaDBServer() ? 71D : 1971D),
-            Optional.of(0D),
+            Optional.of(2000D),
             Optional.empty())
         .verifyComplete();
   }
@@ -378,15 +377,15 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void stringValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
         .as(StepVerifier::create)
-        .expectNext(Optional.of("2060"), Optional.of("2071"), Optional.of("0000"), Optional.empty())
+        .expectNext(Optional.of("2060"), Optional.of("2071"), Optional.of("2000"), Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, String.class))))
@@ -394,7 +393,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(meta.isMariaDBServer() ? "60" : "2060"),
             Optional.of(meta.isMariaDBServer() ? "71" : "1971"),
-            Optional.of(meta.isMariaDBServer() ? "00" : "0000"),
+            Optional.of(meta.isMariaDBServer() ? "00" : "2000"),
             Optional.empty())
         .verifyComplete();
   }
@@ -411,7 +410,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void localDateValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalDate.class))))
@@ -419,11 +418,11 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(LocalDate.parse("2060-01-01")),
             Optional.of(LocalDate.parse("2071-01-01")),
-            Optional.of(LocalDate.parse("0000-01-01")),
+            Optional.of(LocalDate.parse("2000-01-01")),
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, LocalDate.class))))
@@ -431,7 +430,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(LocalDate.parse("2060-01-01")),
             Optional.of(LocalDate.parse("1971-01-01")),
-            Optional.of(LocalDate.parse(meta.isMariaDBServer() ? "2000-01-01" : "0000-01-01")),
+            Optional.of(LocalDate.parse(meta.isMariaDBServer() ? "2000-01-01" : "2000-01-01")),
             Optional.empty())
         .verifyComplete();
   }
@@ -448,7 +447,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void decimalValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -456,11 +455,11 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(new BigDecimal("2060")),
             Optional.of(new BigDecimal("2071")),
-            Optional.of(new BigDecimal("0000")),
+            Optional.of(new BigDecimal("2000")),
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigDecimal.class))))
@@ -468,7 +467,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(new BigDecimal(meta.isMariaDBServer() ? "60" : "2060")),
             Optional.of(new BigDecimal(meta.isMariaDBServer() ? "71" : "1971")),
-            Optional.of(new BigDecimal(meta.isMariaDBServer() ? "00" : "0000")),
+            Optional.of(new BigDecimal(meta.isMariaDBServer() ? "00" : "2000")),
             Optional.empty())
         .verifyComplete();
   }
@@ -485,7 +484,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void bigintValue(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -493,11 +492,11 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(new BigInteger("2060")),
             Optional.of(new BigInteger("2071")),
-            Optional.of(new BigInteger("0")),
+            Optional.of(new BigInteger("2000")),
             Optional.empty())
         .verifyComplete();
     connection
-        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ?")
+        .createStatement("SELECT t2 FROM YearTable WHERE 1 = ? ORDER BY t3")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> Optional.ofNullable(row.get(0, BigInteger.class))))
@@ -505,7 +504,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNext(
             Optional.of(new BigInteger(meta.isMariaDBServer() ? "60" : "2060")),
             Optional.of(new BigInteger(meta.isMariaDBServer() ? "71" : "1971")),
-            Optional.of(BigInteger.ZERO),
+            Optional.of(new BigInteger("2000")),
             Optional.empty())
         .verifyComplete();
   }
@@ -522,7 +521,7 @@ public class YearParseTest extends BaseConnectionTest {
 
   private void meta(MariadbConnection connection) {
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getJavaType()))
@@ -530,7 +529,7 @@ public class YearParseTest extends BaseConnectionTest {
         .expectNextMatches(c -> c.equals(Short.class))
         .verifyComplete();
     connection
-        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? LIMIT 1")
+        .createStatement("SELECT t1 FROM YearTable WHERE 1 = ? ORDER BY t3 LIMIT 1")
         .bind(0, 1)
         .execute()
         .flatMap(r -> r.map((row, metadata) -> metadata.getColumnMetadata(0).getType()))


### PR DESCRIPTION
Added additional columns and sorted the result.
Deleted ZEROFILL columns as this feature is not supported in SingleStore.